### PR TITLE
Flight modal graphs tabs

### DIFF
--- a/webapps/ch2-flight-search-fontend/src/App.css
+++ b/webapps/ch2-flight-search-fontend/src/App.css
@@ -106,16 +106,17 @@ h1 img{
 
 .modal-stats{
   text-align: left;
+  margin-bottom: 10%;
 }
 
-.canvas-container{
+/* .canvas-container{
   margin-bottom: -50%
-}
-.modal canvas{
-  /* position: relative !important; */
+} */
+/* .modal canvas{
+  /* position: relative !important; 
   width: 50% !important;
   height: 100% !important;
-}
+} */
 
 .modal table{
   font-size: medium;

--- a/webapps/ch2-flight-search-fontend/src/App.css
+++ b/webapps/ch2-flight-search-fontend/src/App.css
@@ -100,7 +100,7 @@ h1 img{
   padding: 5%;
   overflow-y: scroll;
 }
-.modal button{
+.modal button.close{
   margin-left: 70vw;
 }
 

--- a/webapps/ch2-flight-search-fontend/src/App.css
+++ b/webapps/ch2-flight-search-fontend/src/App.css
@@ -2,7 +2,7 @@
   text-align: center;
 }
 
-.logo{
+.logo {
   display: block;
   text-align: left;
   margin-left: 10px;
@@ -11,13 +11,15 @@
   padding: 20px 0 0 20px;
 }
 
-.no-flights{
+.no-flights {
   margin-top: 10%;
 }
-.page-container input{
+
+.page-container input {
   padding: 10px;
 }
-.pin{
+
+.pin {
   border-radius: 10px;
   width: 75px;
   height: 50px;
@@ -32,66 +34,64 @@
   cursor: inherit;
 }
 
-.pin-src{
+.pin-src {
   background-color: #CFE3F2;
 }
 
-.pin-dest{
+.pin-dest {
   background-color: #173B56;
   color:white;
 }
 
-.pin-content{
+.pin-content {
   display:inline-block;
   align-items: center;
   justify-content: center;
   text-align: center;
 }
 
-.key{
+.key {
   position: absolute;
   transform: translate(50%,-125%);
 }
 
-.key-content{
+.key-content {
   padding: 10px;
 }
 
-h1 img{
+h1 img {
   width: 2%;
   height: 2%;
 }
-
-
 
 .page-container {
   padding: 0 10% 5% 10%;
 }
 
-.submit-btn{
+.submit-btn {
   display: block;
 }
 
-.airline-containers summary{
+.airline-containers summary {
   text-align: left;
 }
 
-.airline-container{
+.airline-container {
   font-size: x-large;
 }
 
-.airline-container table{
+.airline-container table {
   font-size: medium;
   text-align: left; 
   border-spacing: 20px;
 }
 
-.previous-search{
+.previous-search {
   display: block;
   cursor: pointer;
 }
 
-.modal{
+.modal {
   background-color: white;
   text-align: center;
   width: 75%;
@@ -100,39 +100,32 @@ h1 img{
   padding: 5%;
   overflow-y: scroll;
 }
-.modal button.close{
+
+.modal button.close {
   margin-left: 70vw;
 }
 
-.modal-stats{
+.modal-stats {
   text-align: left;
   margin-bottom: 10%;
 }
 
-/* .canvas-container{
-  margin-bottom: -50%
-} */
-/* .modal canvas{
-  /* position: relative !important; 
-  width: 50% !important;
-  height: 100% !important;
-} */
-
-.modal table{
+.modal table {
   font-size: medium;
   text-align: left; 
   border-spacing: 20px;
 }
 
-#flight-arrival{
-  transform: translate(100%, -100%)
+.MuiButtonBase-root.flightModalTab {
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 4px;
 }
 
-#filter-label{
+#filter-label {
   margin-top: 2%;
 }
 
-.loading{
+.loading {
   color: #173B56;
 }
 
@@ -141,21 +134,25 @@ h1 img{
   50%  { opacity:0; }
   100% { opacity:0.5; }
 }
-@-o-keyframes flickerAnimation{
+
+@-o-keyframes flickerAnimation {
   0%   { opacity:1; }
   50%  { opacity:0; }
   100% { opacity:0.5; }
 }
-@-moz-keyframes flickerAnimation{
+
+@-moz-keyframes flickerAnimation {
   0%   { opacity:1; }
   50%  { opacity:0; }
   100% { opacity:0.5; }
 }
-@-webkit-keyframes flickerAnimation{
+
+@-webkit-keyframes flickerAnimation {
   0%   { opacity:1; }
   50%  { opacity:0; }
   100% { opacity:0.5; }
 }
+
 .animate-flicker {
    -webkit-animation: flickerAnimation 1s infinite;
    -moz-animation: flickerAnimation 1s infinite;

--- a/webapps/ch2-flight-search-fontend/src/components/FlightModal.jsx
+++ b/webapps/ch2-flight-search-fontend/src/components/FlightModal.jsx
@@ -1,275 +1,33 @@
-//what is airline delay?
-import React, {Fragment, useEffect, useState} from 'react';
-import {Button, ExpansionPanel, ExpansionPanelSummary, ExpansionPanelDetails, Tabs, Tab, AppBar} from '@material-ui/core';
-import {formatDate} from '../helpers/checker'
-import Chart from "chart.js";
-import {colorArray} from '../helpers/checker';
+import React, { useState } from 'react';
+import { Button} from '@material-ui/core';
+import { formatDate } from '../helpers/checker';
+import { CanceledStats, FlightStats } from './FlightStats';
+import FlightModalGraphs from './FlightModalGraphs';
 
-const FlightModal = ({airlines, allFlights, filter, filteredFlights, setDisplayModal, flight:{day_of_week, flight_date, airline, tailnumber, flight_number, src, src_city, src_state, dest, dest_city, dest_state, departure_time, actual_departure_time, departure_delay, taxi_out, wheels_off, wheels_on, taxi_in, arrival_time, actual_arrival_time, arrival_delay, cancelled, cancellation_code, flight_time, actual_flight_time, air_time, flights, distance, airline_delay, weather_delay, nas_delay, security_delay, late_aircraft_delay, flightDate_airline_flightNumber}}) => {
-    const [graphDepart, setGraphDepart] = useState(null);
-    const [graphArrival, setGraphArrival] = useState(null);
-    const [graphValue, setGraphValue] = useState(0);
-
-    const findingCurrentAirlineGroup = (currentAirline, airlineGroups) => {
-        for(let i=0; i < airlineGroups.length; i++){
-            if(airlineGroups[i].airline == currentAirline){
-                return airlineGroups[i];
-            }
-        }
+const FlightModal = ({ airlines, allFlights, filter, filteredFlights, setDisplayModal, flight }) => {
+  const findingCurrentAirlineGroup = (currentAirline, airlineGroups) => {
+    for (let i = 0; i < airlineGroups.length; i++) {
+      if (airlineGroups[i].airline === currentAirline) {
+        return airlineGroups[i];
+      }
     }
-    const [currentAirlineGroup, setCurrentAirlineGroup] = useState(findingCurrentAirlineGroup(airline, filteredFlights));
+  }
+  const [currentAirlineGroup, setCurrentAirlineGroup] = useState(findingCurrentAirlineGroup(flight.airline, filteredFlights));
 
-
-    useEffect(() => {
-        const canvasD = document.getElementById('flight-depart');
-        const ctxD = canvasD.getContext("2d");
-
-        const canvasA = document.getElementById('flight-arrival');
-        const ctxA = canvasA.getContext("2d");
-
-
-        
-        if(graphDepart){
-          graphDepart.destroy();
-          setGraphDepart();
-        }
-        if(graphArrival){
-            graphArrival.destroy();
-            setGraphArrival();
-          }
-        
-
-        let initialDeparture = 0;
-        const allFlightDepartDelayAvg = allFlights.reduce((accumulator, flight) => {
-            return accumulator + flight.departure_delay;
-        }, initialDeparture)/allFlights.length;
-        const departData = [arrival_delay, currentAirlineGroup["depart_delay_avg"],  allFlightDepartDelayAvg]
-
-        var departChart = new Chart(ctxD, {
-          type: 'bar',
-          data: {
-              labels: [tailnumber, airlines[airline], "All Flights"],
-              datasets: [{
-                  label: 'Departure Delay (minutes)', //make this dynamic
-                  data: departData,
-    
-
-                  backgroundColor: colorArray(departData, "y"),
-                  borderWidth: 1
-              }]
-          },
-          options: {
-              scales: {
-                  yAxes: [{
-                      ticks: {
-                          beginAtZero: true
-                      }
-                  }]
-              }
-          }
-        });
-        setGraphDepart(departChart);
-
-        let initialArrival = 0;
-        const allFlightArrivalDelayAvg = allFlights.reduce((accumulator, flight) => {
-            return accumulator + flight.arrival_delay;
-        }, initialArrival)/allFlights.length;
-        const arrivalData = [arrival_delay, currentAirlineGroup["arrival_delay_avg"],  allFlightArrivalDelayAvg];
-
-        var arrivalChart = new Chart(ctxA, {
-            type: 'bar',
-            data: {
-                labels: [tailnumber, airlines[airline], "All Flights"],
-                datasets: [{
-                    label: 'Arrival Delay (minutes)',
-                    data: arrivalData,
-      
-                    backgroundColor: colorArray(arrivalData, "g"),
-
-                    borderWidth: 1
-                }]
-            },
-            options: {
-                scales: {
-                    yAxes: [{
-                        ticks: {
-                            beginAtZero: true
-                        }
-                    }]
-                }
-            }
-          });
-          setGraphArrival(arrivalChart);
-      }, [tailnumber]);
-
-    const cancellationCode = (code) => {
-        if("A"){return "Carrier"}
-        else if("B"){return "Weather"}
-        else if("C"){return "National Air System"}
-        else if ("D"){return "Secruity"}
-        else{return "None"}
-    }
-    const canceled_stats = (
-        <Fragment>
-            <ExpansionPanel>
-                <ExpansionPanelSummary>Arrival Stats</ExpansionPanelSummary>
-                <ExpansionPanelDetails>
-                    <h3>Canceled</h3>
-                    <p>{`Cancellation Code: ${cancellation_code}`}</p>
-                    <p>{`Cancellation Reason: ${cancellationCode(cancellation_code)}`}</p>
-                </ExpansionPanelDetails>
-            </ExpansionPanel>
-        </Fragment>
-    );
-
-    const flight_stats = (
-        <Fragment>
-            <ExpansionPanel>
-                <ExpansionPanelSummary>Flight Stats</ExpansionPanelSummary>
-                <ExpansionPanelDetails>
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Flight Legs</th>
-                                <th>Distance</th>
-                                <th>Flight Time</th>
-                                <th>Actual Flight Time</th>
-                                <th>Air Time</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td>{flights}</td>
-                                <td>{distance}</td>
-                                <td>{flight_time}</td>
-                                <td>{actual_flight_time}</td>
-                                <td>{air_time}</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Wheels On</th>
-                                <th>Wheels Off</th>
-                                <th>Taxi In</th>
-                                <th>Taxi Out</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td>{wheels_off}</td>
-                                <td>{wheels_on}</td>
-                                <td>{taxi_in}</td>
-                                <td>{taxi_out}</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </ExpansionPanelDetails>
-            </ExpansionPanel>
-
-            <ExpansionPanel>
-                <ExpansionPanelSummary>Departure Stats</ExpansionPanelSummary>
-                <ExpansionPanelDetails>
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Scheduled Departure</th>
-                                <th>Actual Departure</th>
-                                <th>Departure Delay (min)</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td>{departure_time}</td>
-                                <td>{actual_departure_time}</td>
-                                <td>{departure_delay}</td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </ExpansionPanelDetails>
-            </ExpansionPanel>
-
-            <ExpansionPanel>
-                <ExpansionPanelSummary>Arrival Stats</ExpansionPanelSummary>
-                <ExpansionPanelDetails>
-                <table>
-                    <thead>
-                        <tr>
-                            <th>Scheduled Arrival</th>
-                            <th>Actual Arrival</th>
-                            <th>Arrival Delay (min)</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>{arrival_time}</td>
-                            <td>{actual_arrival_time}</td>
-                            <td>{arrival_delay}</td>
-                        </tr>
-                    </tbody>
-                </table>
-                </ExpansionPanelDetails>
-            </ExpansionPanel>
-
-            <ExpansionPanel>
-                <ExpansionPanelSummary>Delay Stats</ExpansionPanelSummary>
-                <ExpansionPanelDetails>
-                <table>
-                    <thead>
-                        <tr>
-                            <th>Airline Delay</th>
-                            <th>Weather Delay</th>
-                            <th>National Air System Delay</th>
-                            <th>Secruity Delay</th>
-                            <th>Late Aircraft Delay</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            {/* if airline delay is ever changed to 0, can change this back */}
-                            <td>{airline_delay?airline_delay:0}</td>
-                            <td>{weather_delay}</td>
-                            <td>{nas_delay}</td>
-                            <td>{security_delay}</td>
-                            <td>{late_aircraft_delay}</td>
-                        </tr>
-                    </tbody>
-                </table>
-                </ExpansionPanelDetails>
-            </ExpansionPanel>
-        </Fragment>
-    );
-
-    const handleGraphTabChange = (event, newValue) => {
-        setGraphValue(newValue);
-    };
-
-    return (
-        <div className="modal">
-            <Button color="primary" aria-label="close button" className="close" onClick={()=>setDisplayModal(false)}>X</Button>
-                <h1>{`Flight Number ${flight_number}, ${airlines[airline]}`}</h1>
-                <h2>{`${formatDate(flight_date, "dddd, LL")}`}</h2>
-                {/* <h2>{`${src} (${src_city},${src_state}) to ${dest} (${dest_city},${dest_state})`}</h2> */}
-                <h2>{`${src} (${src_city}, ${src_state}) to ${dest} (${dest_city})`}</h2>
-                <h3>{`Tail Number: ${tailnumber}`}</h3>
-
-                <Tabs value={graphValue}  onChange={handleGraphTabChange} variant="standard" aria-label="Arrival and Departure comparison graphs">
-                    <Tab label="Arrival" />
-                    <Tab label="Departure" />
-                </Tabs>
-
-                <div className="canvas-container">
-                    
-                    <canvas id="flight-depart" height="50px" width="50px"></canvas>
-                    <canvas id="flight-arrival" height="50px" width="50px"></canvas>
-                </div>
-                <div className="modal-stats">
-                {cancelled ? canceled_stats : flight_stats}
-                </div>
-                
-        </div>
-    );
+  return (
+    <div className="modal">
+      <Button color="primary" aria-label="close button" className="close" onClick={() => setDisplayModal(false)}>X</Button>
+      <h1>{`Flight Number ${flight.flight_number}, ${airlines[flight.airline]}`}</h1>
+      <h2>{`${formatDate(flight.flight_date, "dddd, LL")}`}</h2>
+      {/* <h2>{`${src} (${src_city},${src_state}) to ${dest} (${dest_city},${dest_state})`}</h2> */}
+      <h2>{`${flight.src} (${flight.src_city}, ${flight.src_state}) to ${flight.dest} (${flight.dest_city})`}</h2>
+      <h3>{`Tail Number: ${flight.tailnumber}`}</h3>
+      <FlightModalGraphs flight={flight} currentAirlineGroup={currentAirlineGroup} allFlights={allFlights} airlines={airlines} />
+      <div className="modal-stats">
+        {flight.cancelled ? <CanceledStats cancellationCode={flight.cancellation_code} /> : <FlightStats flight={flight} />}
+      </div>
+    </div>
+  );
 }
 
 export default FlightModal;

--- a/webapps/ch2-flight-search-fontend/src/components/FlightModal.jsx
+++ b/webapps/ch2-flight-search-fontend/src/components/FlightModal.jsx
@@ -1,6 +1,6 @@
 //what is airline delay?
 import React, {Fragment, useEffect, useState} from 'react';
-import {Button, ExpansionPanel, ExpansionPanelSummary, ExpansionPanelDetails} from '@material-ui/core';
+import {Button, ExpansionPanel, ExpansionPanelSummary, ExpansionPanelDetails, Tabs, Tab, AppBar} from '@material-ui/core';
 import {formatDate} from '../helpers/checker'
 import Chart from "chart.js";
 import {colorArray} from '../helpers/checker';
@@ -8,11 +8,11 @@ import {colorArray} from '../helpers/checker';
 const FlightModal = ({airlines, allFlights, filter, filteredFlights, setDisplayModal, flight:{day_of_week, flight_date, airline, tailnumber, flight_number, src, src_city, src_state, dest, dest_city, dest_state, departure_time, actual_departure_time, departure_delay, taxi_out, wheels_off, wheels_on, taxi_in, arrival_time, actual_arrival_time, arrival_delay, cancelled, cancellation_code, flight_time, actual_flight_time, air_time, flights, distance, airline_delay, weather_delay, nas_delay, security_delay, late_aircraft_delay, flightDate_airline_flightNumber}}) => {
     const [graphDepart, setGraphDepart] = useState(null);
     const [graphArrival, setGraphArrival] = useState(null);
+    const [graphValue, setGraphValue] = useState(0);
 
     const findingCurrentAirlineGroup = (currentAirline, airlineGroups) => {
         for(let i=0; i < airlineGroups.length; i++){
             if(airlineGroups[i].airline == currentAirline){
-                console.log(airlineGroups[i])
                 return airlineGroups[i];
             }
         }
@@ -241,20 +241,33 @@ const FlightModal = ({airlines, allFlights, filter, filteredFlights, setDisplayM
         </Fragment>
     );
 
+    const handleGraphTabChange = (event, newValue) => {
+        setGraphValue(newValue);
+    };
+
     return (
         <div className="modal">
             <Button color="primary" aria-label="close button" className="close" onClick={()=>setDisplayModal(false)}>X</Button>
                 <h1>{`Flight Number ${flight_number}, ${airlines[airline]}`}</h1>
                 <h2>{`${formatDate(flight_date, "dddd, LL")}`}</h2>
-                <h2>{`${src} (${src_city},${src_state}) to ${dest} (${dest_city},${dest_state})`}</h2>
+                {/* <h2>{`${src} (${src_city},${src_state}) to ${dest} (${dest_city},${dest_state})`}</h2> */}
+                <h2>{`${src} (${src_city}, ${src_state}) to ${dest} (${dest_city})`}</h2>
                 <h3>{`Tail Number: ${tailnumber}`}</h3>
+
+                <Tabs value={graphValue}  onChange={handleGraphTabChange} variant="standard" aria-label="Arrival and Departure comparison graphs">
+                    <Tab label="Arrival" />
+                    <Tab label="Departure" />
+                </Tabs>
+
                 <div className="canvas-container">
+                    
                     <canvas id="flight-depart" height="50px" width="50px"></canvas>
                     <canvas id="flight-arrival" height="50px" width="50px"></canvas>
                 </div>
                 <div className="modal-stats">
                 {cancelled ? canceled_stats : flight_stats}
                 </div>
+                
         </div>
     );
 }

--- a/webapps/ch2-flight-search-fontend/src/components/FlightModalGraphs.jsx
+++ b/webapps/ch2-flight-search-fontend/src/components/FlightModalGraphs.jsx
@@ -1,15 +1,10 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import Tabs from '@material-ui/core/Tabs';
-import Tab from '@material-ui/core/Tab';
-import Typography from '@material-ui/core/Typography';
-import Box from '@material-ui/core/Box';
+import { Tabs, Tab, Paper } from '@material-ui/core';
 import Chart from 'chart.js';
-import {colorArray} from '../helpers/checker';
+import { colorArray } from '../helpers/checker';
 
-const TabPanel = (props) => {
-  const { children, value, index, ...other } = props;
-
+const TabPanel = ({ children, value, index, ...other }) => {
   return (
     <div
       role="tabpanel"
@@ -19,9 +14,9 @@ const TabPanel = (props) => {
       {...other}
     >
       {value === index && (
-        <Box m={3}>
-          <Typography>{children}</Typography>
-        </Box>
+        <Paper variant="outlined">
+          {children}
+        </Paper>
       )}
     </div>
   );
@@ -42,13 +37,13 @@ const a11yProps = (index) => {
 
 
 const FlightModalGraphs = ({flight, currentAirlineGroup, allFlights, airlines}) => {
-  const [value, setValue] = React.useState(0);
+  const [value, setValue] = useState(0);
 
   const handleChange = (event, newValue) => {
     setValue(newValue);
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (value === 0) {
       const ctx = document.getElementById("departure-graph");
 
@@ -115,9 +110,9 @@ const FlightModalGraphs = ({flight, currentAirlineGroup, allFlights, airlines}) 
 
   return (
     <React.Fragment>
-      <Tabs value={value} onChange={handleChange} aria-label="simple tabs example">
-        <Tab label="Departure Delay" {...a11yProps(0)} />
-        <Tab label="Arrival Delay" {...a11yProps(1)} />
+      <Tabs value={value} onChange={handleChange} aria-label="simple tabs example" indicatorColor="primary">
+        <Tab label="Departure Delay" className="flightModalTab" {...a11yProps(0)} />
+        <Tab label="Arrival Delay" className="flightModalTab" {...a11yProps(1)} />
       </Tabs>
       <TabPanel value={value} index={0}>
         <canvas id="departure-graph" width="400" height="400"></canvas>

--- a/webapps/ch2-flight-search-fontend/src/components/FlightModalGraphs.jsx
+++ b/webapps/ch2-flight-search-fontend/src/components/FlightModalGraphs.jsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Tabs from '@material-ui/core/Tabs';
+import Tab from '@material-ui/core/Tab';
+import Typography from '@material-ui/core/Typography';
+import Box from '@material-ui/core/Box';
+import Chart from 'chart.js';
+import {colorArray} from '../helpers/checker';
+
+const TabPanel = (props) => {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`flight-graphs-${index}`}
+      aria-labelledby={`flight-graph-tab-${index}`}
+      {...other}
+    >
+      {value === index && (
+        <Box m={3}>
+          <Typography>{children}</Typography>
+        </Box>
+      )}
+    </div>
+  );
+}
+
+TabPanel.propTypes = {
+  children: PropTypes.node,
+  index: PropTypes.any.isRequired,
+  value: PropTypes.any.isRequired,
+};
+
+const a11yProps = (index) => {
+  return {
+    id: `flight-graph-tab-${index}`,
+    'aria-controls': `flight-graphs-${index}`,
+  };
+}
+
+
+const FlightModalGraphs = ({flight, currentAirlineGroup, allFlights, airlines}) => {
+  const [value, setValue] = React.useState(0);
+
+  const handleChange = (event, newValue) => {
+    setValue(newValue);
+  };
+
+  React.useEffect(() => {
+    if (value === 0) {
+      const ctx = document.getElementById("departure-graph");
+
+      let initialDeparture = 0;
+      const allFlightDepartDelayAvg = allFlights.reduce((accumulator, flight) => {
+        return accumulator + flight.departure_delay;
+      }, initialDeparture) / allFlights.length;
+      const departData = [flight.arrival_delay, currentAirlineGroup["depart_delay_avg"], allFlightDepartDelayAvg]
+
+      new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels: [flight.tailnumber, airlines[flight.airline], "All Flights"],
+          datasets: [{
+            label: 'Departure Delay (minutes)', //make this dynamic
+            data: departData,
+            backgroundColor: colorArray(departData, "y"),
+            borderWidth: 1
+          }]
+        },
+        options: {
+          maintainAspectRatio: false,
+          scales: {
+            yAxes: [{
+              ticks: {
+                beginAtZero: true
+              }
+            }]
+          }
+        }
+      });
+    } else {
+      let initialArrival = 0;
+      const allFlightArrivalDelayAvg = allFlights.reduce((accumulator, flight) => {
+        return accumulator + flight.arrival_delay;
+      }, initialArrival) / allFlights.length;
+      const arrivalData = [flight.arrival_delay, currentAirlineGroup["arrival_delay_avg"], allFlightArrivalDelayAvg];
+
+      const ctx2 = document.getElementById("arrival-graph");
+      new Chart(ctx2, {
+        type: 'bar',
+        data: {
+          labels: [flight.tailnumber, airlines[flight.airline], "All Flights"],
+          datasets: [{
+            label: 'Arrival Delay (minutes)',
+            data: arrivalData,
+            backgroundColor: colorArray(arrivalData, "g"),
+            borderWidth: 1
+          }]
+        },
+        options: {
+          maintainAspectRatio: false,
+          scales: {
+            yAxes: [{
+              ticks: {
+                beginAtZero: true
+              }
+            }]
+          }
+        }
+      });
+    }
+  });
+
+  return (
+    <React.Fragment>
+      <Tabs value={value} onChange={handleChange} aria-label="simple tabs example">
+        <Tab label="Departure Delay" {...a11yProps(0)} />
+        <Tab label="Arrival Delay" {...a11yProps(1)} />
+      </Tabs>
+      <TabPanel value={value} index={0}>
+        <canvas id="departure-graph" width="400" height="400"></canvas>
+      </TabPanel>
+      <TabPanel value={value} index={1}>
+        <canvas id="arrival-graph" width="400" height="400"></canvas>
+      </TabPanel>
+    </React.Fragment>
+  )
+};
+
+export default FlightModalGraphs;

--- a/webapps/ch2-flight-search-fontend/src/components/FlightStats.jsx
+++ b/webapps/ch2-flight-search-fontend/src/components/FlightStats.jsx
@@ -1,0 +1,154 @@
+import React from 'react'
+import {ExpansionPanel, ExpansionPanelSummary, ExpansionPanelDetails} from '@material-ui/core';
+
+
+const cancellationCode = (code) => {
+  if(code === "A"){return "Carrier"}
+  else if(code === "B"){return "Weather"}
+  else if(code === "C"){return "National Air System"}
+  else if (code === "D"){return "Security"}
+  else{return "None"}
+}
+
+const CanceledStats = ({cancellationCode}) => {
+  return (
+  <React.Fragment>
+      <ExpansionPanel>
+          <ExpansionPanelSummary>Arrival Stats</ExpansionPanelSummary>
+          <ExpansionPanelDetails>
+              <table>
+                <tr>
+                  <td><h3>Cancelled</h3></td>
+                  <td>{`Cancellation Code: ${cancellationCode}`}</td>
+                  <td>{`Cancellation Reason: ${cancellationCode(cancellationCode)}`}</td>
+                </tr>
+              </table>
+          </ExpansionPanelDetails>
+      </ExpansionPanel>
+  </React.Fragment>)
+};
+
+
+
+const FlightStats = ({flight:{day_of_week, flight_date, airline, tailnumber, flight_number, src, src_city, src_state, dest, dest_city, dest_state, departure_time, actual_departure_time, departure_delay, taxi_out, wheels_off, wheels_on, taxi_in, arrival_time, actual_arrival_time, arrival_delay, cancelled, cancellation_code, flight_time, actual_flight_time, air_time, flights, distance, airline_delay, weather_delay, nas_delay, security_delay, late_aircraft_delay, flightDate_airline_flightNumber}}) => {
+  return (
+    <React.Fragment>
+      <ExpansionPanel>
+        <ExpansionPanelSummary>Flight Stats</ExpansionPanelSummary>
+        <ExpansionPanelDetails>
+          <table>
+            <thead>
+              <tr>
+                <th>Flight Legs</th>
+                <th>Distance</th>
+                <th>Flight Time</th>
+                <th>Actual Flight Time</th>
+                <th>Air Time</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>{flights}</td>
+                <td>{distance}</td>
+                <td>{flight_time}</td>
+                <td>{actual_flight_time}</td>
+                <td>{air_time}</td>
+              </tr>
+            </tbody>
+          </table>
+          <table>
+            <thead>
+              <tr>
+                <th>Wheels On</th>
+                <th>Wheels Off</th>
+                <th>Taxi In</th>
+                <th>Taxi Out</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>{wheels_off}</td>
+                <td>{wheels_on}</td>
+                <td>{taxi_in}</td>
+                <td>{taxi_out}</td>
+              </tr>
+            </tbody>
+          </table>
+        </ExpansionPanelDetails>
+      </ExpansionPanel>
+
+      <ExpansionPanel>
+        <ExpansionPanelSummary>Departure Stats</ExpansionPanelSummary>
+        <ExpansionPanelDetails>
+          <table>
+            <thead>
+              <tr>
+                <th>Scheduled Departure</th>
+                <th>Actual Departure</th>
+                <th>Departure Delay (min)</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>{departure_time}</td>
+                <td>{actual_departure_time}</td>
+                <td>{departure_delay}</td>
+              </tr>
+            </tbody>
+          </table>
+        </ExpansionPanelDetails>
+      </ExpansionPanel>
+
+      <ExpansionPanel>
+        <ExpansionPanelSummary>Arrival Stats</ExpansionPanelSummary>
+        <ExpansionPanelDetails>
+          <table>
+            <thead>
+              <tr>
+                <th>Scheduled Arrival</th>
+                <th>Actual Arrival</th>
+                <th>Arrival Delay (min)</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>{arrival_time}</td>
+                <td>{actual_arrival_time}</td>
+                <td>{arrival_delay}</td>
+              </tr>
+            </tbody>
+          </table>
+        </ExpansionPanelDetails>
+      </ExpansionPanel>
+
+      <ExpansionPanel>
+        <ExpansionPanelSummary>Delay Stats</ExpansionPanelSummary>
+        <ExpansionPanelDetails>
+          <table>
+            <thead>
+              <tr>
+                <th>Airline Delay</th>
+                <th>Weather Delay</th>
+                <th>National Air System Delay</th>
+                <th>Secruity Delay</th>
+                <th>Late Aircraft Delay</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                {/* if airline delay is ever changed to 0, can change this back */}
+                <td>{airline_delay ? airline_delay : 0}</td>
+                <td>{weather_delay}</td>
+                <td>{nas_delay}</td>
+                <td>{security_delay}</td>
+                <td>{late_aircraft_delay}</td>
+              </tr>
+            </tbody>
+          </table>
+        </ExpansionPanelDetails>
+      </ExpansionPanel>
+    </React.Fragment>
+  )
+}
+
+export {CanceledStats, FlightStats};


### PR DESCRIPTION
## User Story
**As a user, I want to adjust the graphs in the flight modal so that I can read them easier**

#### Changes Made
- Moved flight modal graphs and flight stats to their own component files
- Added tabs and tab panels
- Have each graph in a separate tab panel
- Adjust graph size
- Add styling to tabs and tab panels

### AC: 
- [x] Graphs are enlarged to view easier
- [x] Graphs are in a tabbed component

## Type of Changes
<table>
  <tr>
    <th></th>
    <th>Type</th>
  </tr>
  <tr>
    <td></td>
    <td>🐛 Bug Fix</td>
  </tr>
  <tr>
    <td>✓</td>
    <td>✨ New Feature</td>
  </tr>
  <tr>
    <td>✓</td>
    <td>🔨 Refactoring</td>
  </tr>
  <tr>
    <td></td>
    <td>💯 Add tests</td>
  </tr>
  <tr>
    <td></td>
    <td>🔗 Update dependencies</td>
  </tr>
  <tr>
    <td></td>
    <td>📜 Docs</td>
  </tr>
</table>

## Testing Steps / QA Criteria
#### Set up and run the Flask API
1. In `ch2-flight-search-api/creds` add a service account **KEY FILE**
2. Run the following command:
```
export GOOGLE_APPLICATION_CREDENTIALS="[PATH TO KEY FILE]"
```
3. In `ch2-flight-search-api` install or activate your python virtualenv and install all packages in requirements.txt
4. Run the following command to start the application:
```
python3.7 run.py
```
The REST API should now be available on `http://localhost:5000`

#### Set up and run the front end
1. In `ch2-flight-search-fontend` run `npm install` to install project dependencies.
2. Run `npm run start` to start the application

The application should be available on `http://localhost:3000`
